### PR TITLE
Fix auth form names and imports

### DIFF
--- a/src/features/auth/components/password-forgot-form/password-forgot-form.tsx
+++ b/src/features/auth/components/password-forgot-form/password-forgot-form.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { Input } from '@/components/input'
 import { Button } from '@/components/button'
 
-function PasswordForgotFrom(): React.FunctionComponentElement<undefined> {
+function PasswordForgotForm(): React.FunctionComponentElement<undefined> {
   return (
     <>
       <Input type="text" placeholder="E-Mail" />
@@ -11,4 +11,4 @@ function PasswordForgotFrom(): React.FunctionComponentElement<undefined> {
   )
 }
 
-export default PasswordForgotFrom
+export default PasswordForgotForm

--- a/src/features/auth/components/password-reset-form/password-reset-form.tsx
+++ b/src/features/auth/components/password-reset-form/password-reset-form.tsx
@@ -2,14 +2,14 @@ import React from 'react'
 import { Input } from '@/components/input'
 import { Button } from '@/components/button'
 
-function PasswordResetFrom(): React.FunctionComponentElement<undefined> {
+function PasswordResetForm(): React.FunctionComponentElement<undefined> {
   return (
     <>
       <Input type="password" placeholder="Password" />
-      <Input type="password-match" placeholder="Password check" />
+      <Input type="password" placeholder="Password check" />
       <Button>Send</Button>
     </>
   )
 }
 
-export default PasswordResetFrom
+export default PasswordResetForm

--- a/src/features/auth/components/signin-form/signin-form.tsx
+++ b/src/features/auth/components/signin-form/signin-form.tsx
@@ -3,7 +3,7 @@ import { Input } from '@/components/input'
 import { SigninFormProps } from './signin-form.definitions'
 import { Button } from '@/components/button'
 
-function SigninFrom(props: SigninFormProps): React.FunctionComponentElement<SigninFormProps> {
+function SigninForm(props: SigninFormProps): React.FunctionComponentElement<SigninFormProps> {
   return (
     <form {...props}>
       <Input type="text" placeholder="E-Mail" />
@@ -13,4 +13,4 @@ function SigninFrom(props: SigninFormProps): React.FunctionComponentElement<Sign
   )
 }
 
-export default SigninFrom
+export default SigninForm

--- a/src/features/auth/components/signup-form/signup-form.tsx
+++ b/src/features/auth/components/signup-form/signup-form.tsx
@@ -3,15 +3,15 @@ import { Input } from '@/components/input'
 import { SignupFormProps } from './signup-form.definitions'
 import { Button } from '@/components/button'
 
-function SignupFrom(props: SignupFormProps): React.FunctionComponentElement<SignupFormProps> {
+function SignupForm(props: SignupFormProps): React.FunctionComponentElement<SignupFormProps> {
   return (
     <form {...props}>
       <Input type="text" placeholder="E-Mail" />
       <Input type="password" placeholder="Password" />
-      <Input type="password-match" placeholder="Password check" />
+      <Input type="password" placeholder="Password check" />
       <Button>Sign up</Button>
     </form>
   )
 }
 
-export default SignupFrom
+export default SignupForm

--- a/src/features/auth/context/auth-provider.tsx
+++ b/src/features/auth/context/auth-provider.tsx
@@ -1,4 +1,6 @@
 import React from 'react'
+import { AuthContext } from './auth-context'
+import type { User } from './auth-context.definitions'
 
 function AuthProvider({
   children,


### PR DESCRIPTION
## Summary
- import context and types into `AuthProvider`
- fix typos in auth form component names
- use valid password input type

## Testing
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_684c24e60b508331844ed0becae3aa12